### PR TITLE
gulp-notify, yay or nay?

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -7,6 +7,7 @@ filter       = require 'gulp-filter'
 gulp         = require 'gulp'
 gutil        = require 'gulp-util'
 jade         = require 'gulp-jade'
+notify       = require 'gulp-notify'
 path         = require 'path'
 prefix       = require 'gulp-autoprefixer'
 prettyTime   = require 'pretty-hrtime'
@@ -41,6 +42,9 @@ config =
 handleError = (err) ->
   gutil.log err
   gutil.beep()
+  notify
+    .onError title: 'Compile Error', message: '<%= error.message %>'
+    .apply this, Array::slice.call(arguments)
   this.emit 'end'
 
 gulp.task 'scripts', ->

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-filter": "^2.0.2",
     "gulp-jade": "~0.9.0",
     "gulp-minify-css": "~0.3.5",
+    "gulp-notify": "^2.2.0",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-streamify": "0.0.5",
     "gulp-stylus": "~2.0.0",


### PR DESCRIPTION
Pops a notification using native OS notifier if an error occurs
![image](https://cloud.githubusercontent.com/assets/743976/7245359/e4b66966-e7b7-11e4-9b2f-af461d96df90.png)

Missed some errors a few times due to having my computer muted
Feel free to close without merge if 'nay' :)