### PR TITLE
Fixed ESLint rulesets to work on the most recent release

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,7 @@
     "no-dupe-keys": 2, // disallow duplicate keys when creating object literals
     "no-duplicate-case": 2, // disallow a duplicate case label.
     "no-empty": 2, // disallow empty statements
-    "no-empty-class": 2, // disallow the use of empty character classes in regular expressions
+    "no-empty-character-class": 2, // disallow the use of empty character classes in regular expressions
     "no-ex-assign": 2, // disallow assigning to the exception in a catch block
     "no-extra-boolean-cast": 2, // disallow double-negation boolean casts in a boolean context
     "no-extra-parens": 0, // disallow unnecessary parentheses (off by default)
@@ -154,7 +154,7 @@
     "camelcase": 1, // require camel case names
     "comma-spacing": [1, {"before": false, "after": true}], // enforce spacing before and after comma
     "comma-style": [1, "last"], // enforce one true comma style (off by default)
-    "consistent-this": [1, "_this"], // enforces consistent naming when capturing the current execution context (off by default)
+    "consistent-this": [1, "that"], // enforces consistent naming when capturing the current execution context (off by default)
     "eol-last": 1, // enforce newline at the end of file, with no multiple empty lines
     "func-names": 0, // require function expressions to have a name (off by default)
     "func-style": 0, // enforces use of function declarations or expressions (off by default)
@@ -174,7 +174,7 @@
     "no-ternary": 0, // disallow the use of ternary operators (off by default)
     "no-trailing-spaces": 1, // disallow trailing whitespace at the end of lines
     "no-underscore-dangle": 1, // disallow dangling underscores in identifiers
-    "no-wrap-func": 1, // disallow wrapping of non-IIFE statements in parens
+    "no-extra-parens": [1, "functions"], // disallow wrapping of non-IIFE statements in parens
     "one-var": [1, "never"], // allow just one var statement per function (off by default)
     "operator-assignment": [1, "never"], // require assignment operator shorthand where possible or prohibit it entirely (off by default)
     "padded-blocks": [1, "never"], // enforce padding within blocks (off by default)
@@ -186,12 +186,13 @@
     "space-after-keywords": [0, "never"], // require a space after certain keywords (off by default)
     "space-before-blocks": [1, "always"], // require or disallow space before blocks (off by default)
     "space-before-function-paren": [1, {"anonymous": "never", "named": "never"}], // require or disallow space before function opening parenthesis (off by default)
-    "space-in-brackets": [1, "never"], // require or disallow spaces inside brackets (off by default)
+    "object-curly-spacing": [1, "never"], // require or disallow spaces inside curly braces in objects
+    "array-bracket-spacing": [1, "never"], // require or disallow spaces inside of brackets
     "space-in-parens": [1, "never"], // require or disallow spaces inside parentheses (off by default)
-    "space-infix-ops": [1, "always"], // require spaces around operators
-    "space-return-throw-case": [1, "always"], // require a space after return, throw, and case
+    "space-infix-ops": 1, // require spaces around operators
+    "space-return-throw-case": 1, // require a space after return, throw, and case
     "space-unary-ops": [1, {"words": true, "nonwords": false}], // Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
-    "spaced-line-comment": [1, "always"], // require or disallow a space immediately following the // in a line comment (off by default)
+    "spaced-comment": [1, "always"], // require or disallow a space immediately following the // in a line comment (off by default)
     "wrap-regex": 0, // require regex literals to be wrapped in parentheses (off by default)
 
     //


### PR DESCRIPTION
Some of the rules had unnecessary/obsolete parameters which made the linter crash, while others have had their names changed.

There was also a conflicting ruleset regarding the consistent-this rule and no-underscore-dangle. I changed the consistent-this rule to enforce *that* instead of *_this* to fix the issue.