### PR TITLE
Extract js sourcemap into separate .map file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,8 @@ var replace = require('gulp-replace');
 var rev = require('gulp-rev');
 var rimraf = require('rimraf');
 var source = require('vinyl-source-stream');
+var exorcist = require('exorcist');
+var transform  = require('vinyl-transform');
 var sourcemaps = require('gulp-sourcemaps');
 var streamify = require('gulp-streamify');
 var stylus = require('gulp-stylus');
@@ -82,6 +84,10 @@ gulp.task('scripts', function() {
 
   if(production) {
     pipeline = pipeline.pipe(streamify(uglify()));
+  } else {
+    pipeline = pipeline.pipe(transform(function() {
+      return exorcist(config.scripts.destination + config.scripts.filename + '.map');
+    }))
   }
 
   return pipeline.pipe(gulp.dest(config.scripts.destination));
@@ -166,7 +172,11 @@ gulp.task('watch', function() {
       .on('error', handleError)
       .pipe(source(config.scripts.filename));
 
-    build.pipe(gulp.dest(config.scripts.destination))
+    build
+    .pipe(transform(function() {
+      return exorcist(config.scripts.destination + config.scripts.filename + '.map');
+    }))
+    .pipe(gulp.dest(config.scripts.destination))
     .pipe(duration('Rebundling browserify bundle'))
     .pipe(browserSync.reload({stream: true}));
   }).emit('update');

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "browser-sync": "^2.7.2",
     "browserify": "^10.2.1",
     "chai": "^3.0.0",
+    "exorcist": "^0.4.0",
     "gulp": "~3.8.1",
     "gulp-autoprefixer": "1.0.1",
     "gulp-duration": "0.0.0",
@@ -40,6 +41,7 @@
     "node-notifier": "^4.2.1",
     "rimraf": "^2.3.4",
     "vinyl-source-stream": "~1.0.0",
+    "vinyl-transform": "^1.0.0",
     "watchify": "^3.2.1"
   },
   "browserify": {


### PR DESCRIPTION
Occasionally want to open the bundled js file to make sure additional browserify transforms and such were working correctly, having sourcemaps inlined makes Sublime chug a bit much