### PR TITLE
remove "babel" as dependency from package.json (babelify should be enough)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "lodash": "^3.9.1"
   },
   "devDependencies": {
-    "babel": "^5.6.14",
     "babelify": "^6.1.1",
     "browser-sync": "^2.7.2",
     "browserify": "^10.2.1",


### PR DESCRIPTION
"babel" doesn't seem to be required  
The polyfill is also available at in the babelify package via `babelify/polyfill`