### PR TITLE
Inject resources from build directory. obviates rev-manifest.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,7 @@ var stylus = require('gulp-stylus');
 var uglify = require('gulp-uglify');
 var watchify = require('watchify');
 var watch = require('gulp-watch');
+var inject = require('gulp-inject');
 
 /*eslint "no-process-env":0 */
 var production = process.env.NODE_ENV === 'production';
@@ -51,10 +52,8 @@ var config = {
     watch: './src/assets/**/*.*',
     destination: './public/'
   },
-  revision: {
-    source: ['./public/**/*.css', './public/**/*.js'],
-    base: path.join(__dirname, 'public'),
-    destination: './public/'
+  inject: {
+    resources: ['./public/**/*.css', './public/**/*.js']
   }
 };
 
@@ -83,7 +82,9 @@ gulp.task('scripts', function() {
     .pipe(source(config.scripts.filename));
 
   if(production) {
-    pipeline = pipeline.pipe(streamify(uglify()));
+    pipeline = pipeline
+      .pipe(streamify(uglify()))
+      .pipe(streamify(rev()));
   } else {
     pipeline = pipeline.pipe(transform(function() {
       return exorcist(config.scripts.destination + config.scripts.filename + '.map');
@@ -93,12 +94,15 @@ gulp.task('scripts', function() {
   return pipeline.pipe(gulp.dest(config.scripts.destination));
 });
 
-gulp.task('templates', function() {
+gulp.task('templates', production ? ['styles', 'scripts'] : [], function() {
+  var resources = gulp.src(config.inject.resources, {read: false});
+
   var pipeline = gulp.src(config.templates.source)
   .pipe(jade({
     pretty: !production
   }))
   .on('error', handleError)
+  .pipe(inject(resources, {ignorePath: 'public', removeTags: true}))
   .pipe(gulp.dest(config.templates.destination));
 
   if(production) {
@@ -125,7 +129,9 @@ gulp.task('styles', function() {
   .on('error', handleError)
   .pipe(prefix('last 2 versions', 'Chrome 34', 'Firefox 28', 'iOS 7'));
 
-  if(!production) {
+  if(production) {
+    pipeline = pipeline.pipe(rev());
+  } else {
     pipeline = pipeline.pipe(sourcemaps.write('.'));
   }
 
@@ -182,31 +188,5 @@ gulp.task('watch', function() {
   }).emit('update');
 });
 
-var buildTasks = ['templates', 'styles', 'assets'];
-
-gulp.task('revision', buildTasks.concat(['scripts']), function() {
-  return gulp.src(config.revision.source, {base: config.revision.base})
-    .pipe(rev())
-    .pipe(gulp.dest(config.revision.destination))
-    .pipe(rev.manifest())
-    .pipe(gulp.dest('./'));
-});
-
-gulp.task('replace-revision-references', ['revision', 'templates'], function() {
-  var revisions = require('./rev-manifest.json');
-
-  var pipeline = gulp.src(config.templates.revision);
-
-  pipeline = Object.keys(revisions).reduce(function(stream, key) {
-    return stream.pipe(replace(key, revisions[key]));
-  }, pipeline);
-
-  return pipeline.pipe(gulp.dest(config.templates.destination));
-});
-
-gulp.task('build', function() {
-  rimraf.sync(config.destination);
-  gulp.start(buildTasks.concat(['scripts', 'revision', 'replace-revision-references']));
-});
-
-gulp.task('default', buildTasks.concat(['watch', 'server']));
+gulp.task('build', ['styles', 'assets', 'scripts', 'templates']);
+gulp.task('default', ['styles', 'assets', 'templates', 'watch', 'server']);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp": "~3.8.1",
     "gulp-autoprefixer": "1.0.1",
     "gulp-duration": "0.0.0",
+    "gulp-inject": "^3.0.0",
     "gulp-jade": "~0.9.0",
     "gulp-replace": "^0.5.3",
     "gulp-rev": "^4.0.0",

--- a/src/index.jade
+++ b/src/index.jade
@@ -2,7 +2,9 @@ doctype html
 html
   head
     title Gulp template
-    link(rel='stylesheet', href='css/style.css')
+    // inject:css
+    // endinject
   body
     h1 Hello world!
-    script(src='js/bundle.js')
+    // inject:js
+    // endinject


### PR DESCRIPTION
The `template` task needs to wait for the `script` and `styles` tasks to complete before it can run. Until gulp 4.0, [run-sequence](https://www.npmjs.org/package/run-sequence) seems to be required to implement running things in series.

Tasks for managing revisions are no longer necessary.

Should resolve https://github.com/leonidas/gulp-project-template/issues/28