### PR TITLE
ignore config.gypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 public
 .DS_Store
 rev-manifest.json
+config.gypi


### PR DESCRIPTION
doing an npm install from a windows machine results in a build\config.gypi being generated

this file should probably not be tracked

top line of the file: 

># Do not edit. File was generated by node-gyp's "configure" step