### PR TITLE
update gulp-autoprefixer

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -102,7 +102,9 @@ gulp.task('styles', () => {
     compress: production
   }))
   .on('error', handleError)
-  .pipe(prefix(config.styles.browserVersions))
+  .pipe(prefix({
+    browsers: config.styles.browserVersions
+  }))
   .pipe(concat(config.styles.filename));
 
   if(production) {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-react": "^3.4.2",
     "exorcist": "^0.4.0",
     "gulp": "3.9.0",
-    "gulp-autoprefixer": "1.0.1",
+    "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",
     "gulp-duration": "0.0.0",
     "gulp-inject": "^3.0.0",


### PR DESCRIPTION
Was setting up new machines and the old version was inexplicably not including webkit prefixes for flexbox and breaking Safari on iOS 8 

Updated gulp-autoprefixer and that fixed it

Both tests passing
